### PR TITLE
Optimization: get `Observer` constructor in `install` method

### DIFF
--- a/vue-nonreactive.js
+++ b/vue-nonreactive.js
@@ -22,11 +22,11 @@
 
 /* eslint-disable no-param-reassign */
 function install(Vue) {
-    Vue.nonreactive = function nonreactive(value) {
-        const Observer = (new Vue()).$data
-                                    .__ob__
-                                    .constructor;
+    const Observer = (new Vue()).$data
+                                .__ob__
+                                .constructor;
 
+    Vue.nonreactive = function nonreactive(value) {
         // Set dummy observer on value
         value.__ob__ = new Observer({});
         return value;


### PR DESCRIPTION
`Vue.nonreactive` method can be optimized a little by getting `Observer` constructor only once - in the `install` method.