### PR TITLE
fix: Converting circular structure to JSON

### DIFF
--- a/vue-nonreactive.js
+++ b/vue-nonreactive.js
@@ -28,7 +28,12 @@ function install(Vue) {
 
     Vue.nonreactive = function nonreactive(value) {
         // Set dummy observer on value
-        value.__ob__ = new Observer({});
+        Object.defineProperty(value, '__ob__', {
+            value: new Observer({}),
+            enumerable: false,
+            writable: true,
+            configurable: true
+        });
         return value;
     };
 }


### PR DESCRIPTION
JSON.stringify will throw an error when observer instance is circular deps structure.

defineProperty with enumerable was awesome, vue implement:
core/util/lang.js
```
export function def (obj: Object, key: string, val: any, enumerable?: boolean) {
  Object.defineProperty(obj, key, {
    value: val,
    enumerable: !!enumerable,
    writable: true,
    configurable: true
  })
}
```

core/observer/index.js
```
def(value, '__ob__', this)
```